### PR TITLE
Add build way using Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+akochan/.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+FROM rust:1.41
+
+
+# install akochan deps
+RUN set -ex \
+  && apt-get update && apt-get install -y \
+    libboost-all-dev \
+  && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+
+# build akochan ai and system
+# ref: https://github.com/Equim-chan/akochan#systemexe%E3%82%B3%E3%83%B3%E3%83%91%E3%82%A4%E3%83%AB%E6%89%8B%E9%A0%86linux
+WORKDIR /akochan-reviewer
+
+COPY akochan akochan
+
+WORKDIR /akochan-reviewer/akochan/ai_src
+
+RUN set -ex \
+  && make -f Makefile_Linux libai.so \
+  && cp libai.so ../
+
+WORKDIR /akochan-reviewer/akochan
+
+RUN set -ex \
+  && make -f Makefile_Linux system.exe
+
+# set path for system.exe to find libai.so
+ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:/akochan-reviewer/akochan
+
+
+# build akochan-reviewer
+# ref: https://github.com/Equim-chan/akochan-reviewer#build
+WORKDIR /akochan-reviewer
+
+COPY . .
+
+RUN set -ex \
+  && cargo build --release
+
+
+ENTRYPOINT ["./target/release/akochan-reviewer"]

--- a/README.md
+++ b/README.md
@@ -65,6 +65,24 @@ OPTIONS:
                                    FILE is "-", write to stdout
 ```
 
+## Docker
+
+build:
+
+```console
+$ git clone https://github.com/Equim-chan/akochan-reviewer.git
+$ cd akochan-reviewer
+$ git clone https://github.com/Equim-chan/akochan.git
+$ docker build -t akochan-reviewer:latest .
+```
+
+usage:
+
+```console
+$ docker run --rm akochan-reviewer:latest --no-open -t 2019050417gm-0029-0000-4f2a8622 -a 3 -o - > report.html
+$ open report.html  # or just open in browser
+```
+
 ## Acknowledgment
 * [critter](https://twitter.com/critter_Eng): The creater of akochan, who also proposed many advise and gave help to the development of akochan-reviewer.
 


### PR DESCRIPTION
## Description
This tool is interesting, but I felt it was a bit difficult to get started because the build required the Rust environment.
If this project has the option to build using Docker, it will be a bit easier.

## Improvements
- Added Dockerfile
- Described the build procedure and usage in README

## Restrictions
- Lower performance than running locally

## Checking behavior
- ref: https://github.com/yuarasino/akochan-reviewer/tree/feature/build-using-docker#docker

## Testing environment
- Mac OS