### PR TITLE
display end status text

### DIFF
--- a/templates/macros.html
+++ b/templates/macros.html
@@ -56,3 +56,29 @@
     </svg>
   {% endif %}
 {% endmacro render_action %}
+
+{%- macro render_actor(actor, target_actor) -%}
+  {%- if (actor - target_actor + 4) % 4 == 1 -%}
+    下家
+  {%- elif (actor - target_actor + 4) % 4 == 2 -%}
+    対面
+  {%- elif (actor - target_actor + 4) % 4 == 3 -%}
+    上家
+  {%- else -%}
+    自家
+  {%- endif -%}
+{%- endmacro -%}
+
+{%- macro render_end_status(end_status, target_actor) -%}
+  {%- if end_status.type == "hora" -%}
+    {%- if end_status.target == end_status.actor -%}
+      ツモ
+    {%- else -%}
+      ロン
+    {%- endif -%}:
+    {{ self::render_actor(actor=end_status.actor, target_actor=target_actor) }}
+    {{ end_status.deltas[end_status.actor] }}
+  {%- else -%}
+    流局
+  {%- endif -%}
+{%- endmacro render_end_status -%}

--- a/templates/report.html
+++ b/templates/report.html
@@ -209,7 +209,7 @@
     .kyoku-heading .end-status {
       font-size: 75%;
       font-weight: normal;
-      vertical-align: bottom;
+      line-height: 75%;
     }
 
     .sticky {

--- a/templates/report.html
+++ b/templates/report.html
@@ -13,15 +13,28 @@
   <h1>目次</h1>
   <details open class="collapse">
     <summary></summary>
-    <ol>
-      {% for item in kyokus %}
-        <li>
-          <a href="#kyoku-{{ item.kyoku }}-{{ item.honba }}">
-            {{ kyoku_to_string(kyoku=item.kyoku, honba=item.honba) }}
-          </a>
-        </li>
-      {% endfor %}
-    </ol>
+    <div class="kyoku-toc">
+      <ol class="kyoku-list">
+        {% for item in kyokus %}
+          <li class="kyoku-item">
+            <a href="#kyoku-{{ item.kyoku }}-{{ item.honba }}">
+              {{ kyoku_to_string(kyoku=item.kyoku, honba=item.honba) }}
+            </a>
+          </li>
+        {% endfor %}
+      </ol>
+      <ol class="end-status-list">
+        {% for item in kyokus %}
+          <li class="end-status-item">
+            <span class="end-status">
+              {% for end_status in item.end_status %}
+                {{ macros::render_end_status(end_status=end_status, target_actor=target_actor) }}
+              {% endfor %}
+            </span>
+          </li>
+        {% endfor %}
+      </ol>
+    </div>
   </details>
 
   <details class="collapse">
@@ -40,14 +53,20 @@
 
   {% for item in kyokus %}
     <section style="z-index: {{ 10 + loop.index0 }}">
-      <h1 id="kyoku-{{ item.kyoku }}-{{ item.honba }}">
-        <a href="#kyoku-{{ item.kyoku }}-{{ item.honba }}" class="chapter">
-          {{ kyoku_to_string(kyoku=item.kyoku, honba=item.honba) }}
-        </a>
+      <h1 id="kyoku-{{ item.kyoku }}-{{ item.honba }}" class="kyoku-heading">
+        <div class="kyoku-item">
+          <a href="#kyoku-{{ item.kyoku }}-{{ item.honba }}" class="chapter">
+            {{ kyoku_to_string(kyoku=item.kyoku, honba=item.honba) }}
+          </a>
+        </div>
+        <div class="end-status-item">
+          <span class="end-status">
+            {% for end_status in item.end_status %}
+              {{ macros::render_end_status(end_status=end_status, target_actor=target_actor) }}
+            {% endfor %}
+          </span>
+        </div>
       </h1>
-
-      {# TODO: render these #}
-      <pre>{{ item.end_status | json_encode() }}</pre>
 
       {% if splited_logs is defined %}
         <div class="sticky" style="z-index: {{ 15 + loop.index0 }}">
@@ -167,6 +186,30 @@
     details[open].collapse summary {
       border-bottom: 1px solid #aaa;
       margin-bottom: .5em;
+    }
+
+    .kyoku-toc, 
+    .kyoku-heading {
+      display: flex;
+    }
+
+    .end-status-list {
+      list-style: none;
+      padding-left: 0;
+    }
+
+    .end-status-item {
+      margin-left: 2em;
+    }
+
+    .end-status {
+      color: #666;
+    }
+
+    .kyoku-heading .end-status {
+      font-size: 75%;
+      font-weight: normal;
+      vertical-align: bottom;
     }
 
     .sticky {


### PR DESCRIPTION
## Issue
close #2 

## Screen Shots
### ロン・ツモ・流局 Sample
<img width="813" alt="スクリーンショット 2020-03-11 22 12 50" src="https://user-images.githubusercontent.com/37145593/76420517-92379c00-63e5-11ea-8b91-5201f511a3dd.png">

### Double ロン Sample
<img width="903" alt="スクリーンショット 2020-03-11 21 48 43" src="https://user-images.githubusercontent.com/37145593/76419028-03c21b00-63e3-11ea-8fc1-135cadfcdd05.png">
