### PR TITLE
Add a new horizontal layout for the report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Cargo.lock
 .vscode/
 
 *.html
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ OPTIONS:
                                              "E1,E4,S3.1".
         --lang <LANG>                        Set the language for the rendered report page. Default value "ja".
                                              Supported languages: ja, en.
+        --layout <LAYOUT>                    Set the layout for the rendered report page. Default value "vertical".
+                                             Supported layout: vertical, v, horizontal, h.
         --mjai-out <FILE>                    Save the transformed mjai format log to FILE. If FILE is "-", write to
                                              stdout.
     -m, --mjsoul-id <ID>                     Specify a Mahjong Soul log ID to review. Example: "200417-e1f9e08d-487f-

--- a/src/render.rs
+++ b/src/render.rs
@@ -36,6 +36,14 @@ pub enum Language {
     English,
 }
 
+#[derive(Serialize)]
+pub enum Layout {
+    #[serde(rename="horizontal")]
+    Horizontal,
+    #[serde(rename="vertical")]
+    Vertical
+}
+
 #[allow(clippy::unnecessary_wraps)]
 fn kyoku_to_string_ja(args: &HashMap<String, Value>) -> tera::Result<Value> {
     const BAKAZE_KANJI: &[&str] = &["東", "南", "西", "北"];
@@ -99,6 +107,7 @@ where
     splited_logs: Option<L>,
     metadata: &'a Metadata<'a>,
     lang: Language,
+    layout: Layout,
 }
 
 impl<'a, L> View<'a, L>
@@ -109,16 +118,18 @@ where
     pub fn new(
         kyoku_reviews: &'a [KyokuReview],
         target_actor: u8,
-        splited_logs: Option<L>,
+        splitted_logs: Option<L>,
         metadata: &'a Metadata<'a>,
         lang: Language,
+        layout: Layout
     ) -> Self {
         Self {
             kyokus: kyoku_reviews,
             target_actor,
-            splited_logs,
+            splited_logs: splitted_logs,
             metadata,
             lang,
+            layout,
         }
     }
 

--- a/src/render.rs
+++ b/src/render.rs
@@ -38,10 +38,10 @@ pub enum Language {
 
 #[derive(Serialize)]
 pub enum Layout {
-    #[serde(rename="horizontal")]
+    #[serde(rename = "horizontal")]
     Horizontal,
-    #[serde(rename="vertical")]
-    Vertical
+    #[serde(rename = "vertical")]
+    Vertical,
 }
 
 #[allow(clippy::unnecessary_wraps)]
@@ -121,7 +121,7 @@ where
         splitted_logs: Option<L>,
         metadata: &'a Metadata<'a>,
         lang: Language,
-        layout: Layout
+        layout: Layout,
     ) -> Self {
         Self {
             kyokus: kyoku_reviews,

--- a/src/render.rs
+++ b/src/render.rs
@@ -21,6 +21,7 @@ static TEMPLATES: Lazy<Tera> = Lazy::new(|| {
         ("pai.svg", include_str!("../assets/pai.svg")),
         ("report.css", include_str!("../templates/report.css")),
         ("report.html", include_str!("../templates/report.html")),
+        ("report.js", include_str!("../templates/report.js")),
     ])
     .expect("failed to parse template");
 

--- a/src/review.rs
+++ b/src/review.rs
@@ -149,7 +149,7 @@ pub fn review(review_args: &ReviewArgs) -> Result<Review> {
             log!("> {}", to_write);
         }
 
-        // upate the state
+        // update the state
         state.update(event).context("failed to update state")?;
 
         // this match does two things:
@@ -246,7 +246,7 @@ pub fn review(review_args: &ReviewArgs) -> Result<Review> {
             continue;
         }
 
-        // skip the comparision when
+        // skip the comparison when
         // 1. it is not our turn and there is no chance to naki
         // 2. our state is reached and only tsumogiri is possible
         if actions.len() == 1 && (is_reached || actions[0].moves[0] == Event::None) {

--- a/templates/report.css
+++ b/templates/report.css
@@ -6,6 +6,9 @@ body {
   margin: auto;
   background: #f2f2f2;
 }
+body[horizontal] {
+  max-width: 1600px;
+}
 
 h1 {
   font-size: 2em;
@@ -146,4 +149,11 @@ table.stat th {
 table.stat td {
   font-size: 90%;
   line-height: 32px;
+}
+.l-box[horizontal] {
+  float: left;
+  width: 50%;
+}
+.r-box[horizontal] {
+  margin-left: 50%;
 }

--- a/templates/report.html
+++ b/templates/report.html
@@ -14,11 +14,11 @@
   <title>{% if lang == "en" %}Replay Examination{% else %}牌譜検討{% endif %}</title>
 </head>
 
-<body>
+<body {% if layout == "horizontal" %} horizontal="1" {% endif %} >
   <h1>{% if lang == "en" %}Replay Examination{% else %}牌譜検討{% endif %}</h1>
 
-  <input type="radio" name="style" id="radio_style_v" checked="true" onclick="toggleStyle()" />vertical
-  <input type="radio" name="style" id="radio_style_h" onclick="toggleStyle()" />horizontal
+  <input type="radio" name="style" id="radio_style_v" {% if layout == "vertical" %} checked="true" {% endif %} onclick="toggleStyle()" />vertical
+  <input type="radio" name="style" id="radio_style_h" {% if layout == "horizontal" %} checked="true" {% endif %} onclick="toggleStyle()" />horizontal
 
   <details open class="collapse">
     <summary>{% if lang == "en" %}Game Summary{% else %}目次{% endif %}</summary>
@@ -102,7 +102,7 @@
       </h1>
 
       {%- if splited_logs is defined -%}
-        <div class="sticky l-box" style="z-index: {{ 15 + loop.index0 }}">
+        <div class="sticky l-box" style="z-index: {{ 15 + loop.index0 }}" {% if layout == "horizontal" %} horizontal="1" {% endif %} >
           <details open class="collapse">
             <summary>{% if lang == "en" %}Replay Viewer{%- else -%}牌譜ビューア{% endif %}</summary>
             <iframe
@@ -117,7 +117,7 @@
         </div>
       {%- endif -%}
 
-      <div class="r-box">
+      <div class="r-box" {% if layout == "horizontal" %} horizontal="1" {% endif %} >
       {%- for entry in item.entries -%}
         {%- if entry.acceptance == "disagree" -%}
           <details open class="collapse">

--- a/templates/report.html
+++ b/templates/report.html
@@ -17,6 +17,9 @@
 <body>
   <h1>{% if lang == "en" %}Replay Examination{% else %}牌譜検討{% endif %}</h1>
 
+  <input type="radio" name="style" id="radio_style_v" checked="true" onclick="toggleStyle()" />vertical
+  <input type="radio" name="style" id="radio_style_h" onclick="toggleStyle()" />horizontal
+
   <details open class="collapse">
     <summary>{% if lang == "en" %}Game Summary{% else %}目次{% endif %}</summary>
     <div class="kyoku-toc">
@@ -99,7 +102,7 @@
       </h1>
 
       {%- if splited_logs is defined -%}
-        <div class="sticky" style="z-index: {{ 15 + loop.index0 }}">
+        <div class="sticky l-box" style="z-index: {{ 15 + loop.index0 }}">
           <details open class="collapse">
             <summary>{% if lang == "en" %}Replay Viewer{%- else -%}牌譜ビューア{% endif %}</summary>
             <iframe
@@ -114,6 +117,7 @@
         </div>
       {%- endif -%}
 
+      <div class="r-box">
       {%- for entry in item.entries -%}
         {%- if entry.acceptance == "disagree" -%}
           <details open class="collapse">
@@ -252,9 +256,35 @@
           {%- endif -%}
         </details>
       {%- endfor -%}
+      </div>
     </section>
   {%- endfor -%}
 
+  <script>
+    function toggleStyle() {
+      if (document.getElementById("radio_style_v").checked) {
+        document.body.removeAttribute("horizontal")
+        lboxes = document.querySelectorAll(".l-box")
+        for (var i = 0; i < lboxes.length; i++) {
+          lboxes[i].removeAttribute("horizontal")
+        }
+        rboxes = document.querySelectorAll(".r-box")
+        for (var i = 0; i < rboxes.length; i++) {
+          rboxes[i].removeAttribute("horizontal")
+        }
+      } else {
+        document.body.setAttribute("horizontal", "1")
+        lboxes = document.querySelectorAll(".l-box")
+        for (var i = 0; i < lboxes.length; i++) {
+          lboxes[i].setAttribute("horizontal", "1")
+        }
+        rboxes = document.querySelectorAll(".r-box")
+        for (var i = 0; i < rboxes.length; i++) {
+          rboxes[i].setAttribute("horizontal", "1")
+        }
+      }
+    }
+  </script>
   <style>{%- include "report.css" -%}</style>
   {%- include "pai.svg" -%}
 

--- a/templates/report.html
+++ b/templates/report.html
@@ -103,7 +103,7 @@
 
       {%- if splited_logs is defined -%}
         <div class="sticky l-box" style="z-index: {{ 15 + loop.index0 }}" {% if layout == "horizontal" %} horizontal="1" {% endif %} >
-          <details open class="collapse">
+          <details {% if item.entries | length != 0 %} open {% endif %} class="collapse">
             <summary>{% if lang == "en" %}Replay Viewer{%- else -%}牌譜ビューア{% endif %}</summary>
             <iframe
               src="https://tenhou.net/5/?tw={{ target_actor }}#json={{ splited_logs[loop.index0] | json_encode() }}"
@@ -118,6 +118,17 @@
       {%- endif -%}
 
       <div class="r-box" {% if layout == "horizontal" %} horizontal="1" {% endif %} >
+      {%- if item.entries | length == 0 -%}
+      <details class="collapse">
+        <summary>
+            {%- if lang == "en" -%}
+              Turn 0
+            {%- else -%}
+              0 巡
+            {%- endif -%}
+        </summary>
+      </details>
+      {%- endif -%}
       {%- for entry in item.entries -%}
         {%- if entry.acceptance == "disagree" -%}
           <details open class="collapse">

--- a/templates/report.html
+++ b/templates/report.html
@@ -18,7 +18,7 @@
   <h1>{% if lang == "en" %}Replay Examination{% else %}牌譜検討{% endif %}</h1>
 
   <label for="radio_style_v"><input type="radio" name="style" id="radio_style_v" {% if layout == "vertical" %} checked="true" {% endif %} onclick="toggleStyle()" />vertical</label>
-  <label for="radio_style_v"><input type="radio" name="style" id="radio_style_h" {% if layout == "horizontal" %} checked="true" {% endif %} onclick="toggleStyle()" />horizontal</label>
+  <label for="radio_style_h"><input type="radio" name="style" id="radio_style_h" {% if layout == "horizontal" %} checked="true" {% endif %} onclick="toggleStyle()" />horizontal</label>
 
   <details open class="collapse">
     <summary>{% if lang == "en" %}Game Summary{% else %}目次{% endif %}</summary>

--- a/templates/report.html
+++ b/templates/report.html
@@ -271,31 +271,7 @@
     </section>
   {%- endfor -%}
 
-  <script>
-    function toggleStyle() {
-      if (document.getElementById("radio_style_v").checked) {
-        document.body.removeAttribute("horizontal")
-        lboxes = document.querySelectorAll(".l-box")
-        for (var i = 0; i < lboxes.length; i++) {
-          lboxes[i].removeAttribute("horizontal")
-        }
-        rboxes = document.querySelectorAll(".r-box")
-        for (var i = 0; i < rboxes.length; i++) {
-          rboxes[i].removeAttribute("horizontal")
-        }
-      } else {
-        document.body.setAttribute("horizontal", "1")
-        lboxes = document.querySelectorAll(".l-box")
-        for (var i = 0; i < lboxes.length; i++) {
-          lboxes[i].setAttribute("horizontal", "1")
-        }
-        rboxes = document.querySelectorAll(".r-box")
-        for (var i = 0; i < rboxes.length; i++) {
-          rboxes[i].setAttribute("horizontal", "1")
-        }
-      }
-    }
-  </script>
+  <script>{%- include "report.js" -%}</script>
   <style>{%- include "report.css" -%}</style>
   {%- include "pai.svg" -%}
 

--- a/templates/report.html
+++ b/templates/report.html
@@ -17,8 +17,8 @@
 <body {% if layout == "horizontal" %} horizontal="1" {% endif %} >
   <h1>{% if lang == "en" %}Replay Examination{% else %}牌譜検討{% endif %}</h1>
 
-  <input type="radio" name="style" id="radio_style_v" {% if layout == "vertical" %} checked="true" {% endif %} onclick="toggleStyle()" />vertical
-  <input type="radio" name="style" id="radio_style_h" {% if layout == "horizontal" %} checked="true" {% endif %} onclick="toggleStyle()" />horizontal
+  <label for="radio_style_v"><input type="radio" name="style" id="radio_style_v" {% if layout == "vertical" %} checked="true" {% endif %} onclick="toggleStyle()" />vertical</label>
+  <label for="radio_style_v"><input type="radio" name="style" id="radio_style_h" {% if layout == "horizontal" %} checked="true" {% endif %} onclick="toggleStyle()" />horizontal</label>
 
   <details open class="collapse">
     <summary>{% if lang == "en" %}Game Summary{% else %}目次{% endif %}</summary>

--- a/templates/report.html
+++ b/templates/report.html
@@ -17,8 +17,8 @@
 <body {% if layout == "horizontal" %} horizontal="1" {% endif %} >
   <h1>{% if lang == "en" %}Replay Examination{% else %}牌譜検討{% endif %}</h1>
 
-  <label for="radio_style_v"><input type="radio" name="style" id="radio_style_v" {% if layout == "vertical" %} checked="true" {% endif %} onclick="toggleStyle()" />vertical</label>
-  <label for="radio_style_h"><input type="radio" name="style" id="radio_style_h" {% if layout == "horizontal" %} checked="true" {% endif %} onclick="toggleStyle()" />horizontal</label>
+  <label><input type="radio" name="style" id="radio_style_v" {% if layout == "vertical" %} checked="true" {% endif %} onclick="toggleStyle()" />vertical</label>
+  <label><input type="radio" name="style" id="radio_style_h" {% if layout == "horizontal" %} checked="true" {% endif %} onclick="toggleStyle()" />horizontal</label>
 
   <details open class="collapse">
     <summary>{% if lang == "en" %}Game Summary{% else %}目次{% endif %}</summary>

--- a/templates/report.js
+++ b/templates/report.js
@@ -1,0 +1,23 @@
+function toggleStyle() {
+    if (document.getElementById("radio_style_v").checked) {
+        document.body.removeAttribute("horizontal")
+        lboxes = document.querySelectorAll(".l-box")
+        for (var i = 0; i < lboxes.length; i++) {
+            lboxes[i].removeAttribute("horizontal")
+        }
+        rboxes = document.querySelectorAll(".r-box")
+        for (var i = 0; i < rboxes.length; i++) {
+            rboxes[i].removeAttribute("horizontal")
+        }
+    } else {
+        document.body.setAttribute("horizontal", "1")
+        lboxes = document.querySelectorAll(".l-box")
+        for (var i = 0; i < lboxes.length; i++) {
+            lboxes[i].setAttribute("horizontal", "1")
+        }
+        rboxes = document.querySelectorAll(".r-box")
+        for (var i = 0; i < rboxes.length; i++) {
+            rboxes[i].setAttribute("horizontal", "1")
+        }
+    }
+}


### PR DESCRIPTION
close #50 

As mentioned in #50, I find there is only limited space if I don't collapse the tenhou replay iframe.

I add a horizontal layout to place the tenhou replay to the left and the review result to the right side.

A preview for the report with horizontal layout:
[chankan.json.html.zip](https://github.com/Equim-chan/akochan-reviewer/files/8308615/chankan.json.html.zip)
![image](https://user-images.githubusercontent.com/4865550/159107530-4726c89d-0ad3-407b-8616-2c480803dd8d.png)