### PR TITLE
Add an error msg when "actor-name" is specified but not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ FLAGS:
 OPTIONS:
     -a, --actor <INDEX>                      Specify the actor to review. It is the number after "&tw=" in tenhou's log
                                              url.
+        --actor-name <ACTOR_NAME>            Specify the actor name to review when --in-file is specified and --actor is
+                                             not specified
     -d, --akochan-dir <DIR>                  Specify the directory of akochan. This will serve as the working directory
                                              of akochan process. Default value "akochan".
     -n, --deviation-threshold <THRESHOLD>    THRESHOLD is an absolute value that the reviewer will ignore all

--- a/src/main.rs
+++ b/src/main.rs
@@ -492,6 +492,14 @@ fn main() -> Result<()> {
                     actor_opt = Some(idx as u8)
                 }
             }
+            // can not find actor index by name, return available players name
+            if actor_opt.is_none() {
+                return Err(anyhow!(
+                    "there are no player with name \"{}\", available players: {}",
+                    actor_name,
+                    raw_log.get_names().join(", ")
+                ));
+            }
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -493,13 +493,12 @@ fn main() -> Result<()> {
                 }
             }
             // can not find actor index by name, return available players name
-            if actor_opt.is_none() {
-                return Err(anyhow!(
-                    "there are no player with name \"{}\", available players: {}",
-                    actor_name,
-                    raw_log.get_names().join(", ")
-                ));
-            }
+            anyhow::ensure!(
+                actor_opt.is_some(),
+                "there is no player named \"{}\", available players: {}",
+                actor_name,
+                raw_log.get_names().join(", "),
+            );
         }
     }
 


### PR DESCRIPTION
* Update README.md for #49
* Add an error msg when "actor-name" is specified but not found
```
>  ./run-test.sh convlog/tests/testdata/chankan.json
+ INPUT_FILE=convlog/tests/testdata/chankan.json
+ ./target/release/akochan-reviewer -d ../akochan/ --actor-name $'AA�\201\225�\202\223' --layout h -i convlog/tests/testdata/chankan.json
Error: there are no player with name "AAさん", available players: Aさん, Bさん, Cさん, Dさん
```